### PR TITLE
Initialize NestJS backend skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# MMA Platform Backend
+
+This project is a minimal example of a NestJS backend for an MMA platform using GraphQL and TypeORM. It demonstrates a clean architecture-style folder structure and includes entities for fighters, events, fights and rankings.
+
+## Ranking Algorithm
+
+After each fight result is recorded, fighters earn points based on the result:
+
+- **Win by KO/TKO or Submission**: +4 points
+- **Win by Decision**: +3 points
+- **Draw**: +1 point
+- **Loss**: 0 points
+
+Rankings are recalculated per weight class whenever points change.
+
+## Development
+
+Install dependencies and run in watch mode:
+
+```bash
+npm install
+npm run start:dev
+```
+
+The app will start on http://localhost:3000 and provide a GraphQL endpoint at `/graphql`.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "mma-platform",
+  "version": "0.1.0",
+  "description": "MMA platform backend using NestJS, GraphQL, and TypeORM",
+  "private": true,
+  "scripts": {
+    "start": "nest start",
+    "start:dev": "nest start --watch",
+    "build": "nest build",
+    "lint": "eslint . --ext .ts"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/graphql": "^10.0.0",
+    "@nestjs/platform-express": "^10.0.0",
+    "@nestjs/typeorm": "^10.0.0",
+    "apollo-server-express": "^3.12.0",
+    "graphql": "^16.6.0",
+    "reflect-metadata": "^0.1.13",
+    "rxjs": "^7.8.0",
+    "typeorm": "^0.3.17",
+    "pg": "^8.10.0",
+    "class-validator": "^0.14.0",
+    "class-transformer": "^0.5.1"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "^10.0.0",
+    "@nestjs/schematics": "^10.0.0",
+    "@types/node": "^18.16.0",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.0.4",
+    "eslint": "^8.38.0",
+    "@typescript-eslint/parser": "^5.59.0",
+    "@typescript-eslint/eslint-plugin": "^5.59.0"
+  }
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,0 +1,31 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { GraphQLModule } from '@nestjs/graphql';
+import { join } from 'path';
+import { FightersModule } from './fighters/fighters.module';
+import { EventsModule } from './events/events.module';
+import { FightsModule } from './fights/fights.module';
+import { RankingsModule } from './rankings/rankings.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forRoot({
+      type: 'postgres',
+      host: 'localhost',
+      port: 5432,
+      username: 'postgres',
+      password: 'postgres',
+      database: 'mma',
+      autoLoadEntities: true,
+      synchronize: true,
+    }),
+    GraphQLModule.forRoot({
+      autoSchemaFile: join(process.cwd(), 'schema.gql'),
+    }),
+    FightersModule,
+    EventsModule,
+    FightsModule,
+    RankingsModule,
+  ],
+})
+export class AppModule {}

--- a/src/events/application/events.service.ts
+++ b/src/events/application/events.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Event } from '../domain/event.entity';
+import { CreateEventInput } from '../presentation/dto/create-event.input';
+
+@Injectable()
+export class EventsService {
+  constructor(
+    @InjectRepository(Event)
+    private events: Repository<Event>,
+  ) {}
+
+  create(input: CreateEventInput) {
+    const event = this.events.create(input);
+    return this.events.save(event);
+  }
+
+  findAll() {
+    return this.events.find({ relations: ['fights'] });
+  }
+
+  findOne(id: number) {
+    return this.events.findOne({ where: { id }, relations: ['fights'] });
+  }
+}

--- a/src/events/domain/event.entity.ts
+++ b/src/events/domain/event.entity.ts
@@ -1,0 +1,30 @@
+import { Field, ObjectType } from '@nestjs/graphql';
+import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
+import { Fight } from '../../fights/domain/fight.entity';
+
+@ObjectType()
+@Entity('events')
+export class Event {
+  @Field()
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Field()
+  @Column()
+  name: string;
+
+  @Field()
+  @Column({ type: 'date' })
+  eventDate: string;
+
+  @Field({ nullable: true })
+  @Column({ nullable: true })
+  location?: string;
+
+  @Field({ nullable: true })
+  @Column({ nullable: true })
+  promotion?: string;
+
+  @OneToMany(() => Fight, fight => fight.event)
+  fights: Fight[];
+}

--- a/src/events/events.module.ts
+++ b/src/events/events.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Event } from './domain/event.entity';
+import { EventsService } from './application/events.service';
+import { EventsResolver } from './presentation/events.resolver';
+import { Fight } from '../fights/domain/fight.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Event, Fight])],
+  providers: [EventsService, EventsResolver],
+  exports: [EventsService],
+})
+export class EventsModule {}

--- a/src/events/presentation/dto/create-event.input.ts
+++ b/src/events/presentation/dto/create-event.input.ts
@@ -1,0 +1,19 @@
+import { Field, InputType } from '@nestjs/graphql';
+import { IsNotEmpty } from 'class-validator';
+
+@InputType()
+export class CreateEventInput {
+  @Field()
+  @IsNotEmpty()
+  name: string;
+
+  @Field()
+  @IsNotEmpty()
+  eventDate: string;
+
+  @Field({ nullable: true })
+  location?: string;
+
+  @Field({ nullable: true })
+  promotion?: string;
+}

--- a/src/events/presentation/events.resolver.ts
+++ b/src/events/presentation/events.resolver.ts
@@ -1,0 +1,24 @@
+import { Args, Int, Mutation, Query, Resolver } from '@nestjs/graphql';
+import { EventsService } from '../application/events.service';
+import { Event } from '../domain/event.entity';
+import { CreateEventInput } from './dto/create-event.input';
+
+@Resolver(() => Event)
+export class EventsResolver {
+  constructor(private service: EventsService) {}
+
+  @Query(() => [Event])
+  events() {
+    return this.service.findAll();
+  }
+
+  @Query(() => Event, { nullable: true })
+  event(@Args('id', { type: () => Int }) id: number) {
+    return this.service.findOne(id);
+  }
+
+  @Mutation(() => Event)
+  createEvent(@Args('input') input: CreateEventInput) {
+    return this.service.create(input);
+  }
+}

--- a/src/fighters/application/fighters.service.ts
+++ b/src/fighters/application/fighters.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Fighter } from '../domain/fighter.entity';
+import { CreateFighterInput } from '../presentation/dto/create-fighter.input';
+
+@Injectable()
+export class FightersService {
+  constructor(
+    @InjectRepository(Fighter)
+    private fighters: Repository<Fighter>,
+  ) {}
+
+  create(input: CreateFighterInput) {
+    const fighter = this.fighters.create(input);
+    return this.fighters.save(fighter);
+  }
+
+  findAll() {
+    return this.fighters.find();
+  }
+
+  findOne(id: number) {
+    return this.fighters.findOne({ where: { id } });
+  }
+}

--- a/src/fighters/domain/fighter.entity.ts
+++ b/src/fighters/domain/fighter.entity.ts
@@ -1,0 +1,42 @@
+import { Field, ObjectType } from '@nestjs/graphql';
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+
+@ObjectType()
+@Entity('fighters')
+export class Fighter {
+  @Field()
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Field()
+  @Column()
+  name: string;
+
+  @Field()
+  @Column()
+  weightClass: string;
+
+  @Field({ nullable: true })
+  @Column({ type: 'date', nullable: true })
+  dob?: string;
+
+  @Field({ defaultValue: 0 })
+  @Column({ default: 0 })
+  wins: number;
+
+  @Field({ defaultValue: 0 })
+  @Column({ default: 0 })
+  losses: number;
+
+  @Field({ defaultValue: 0 })
+  @Column({ default: 0 })
+  draws: number;
+
+  @Field({ defaultValue: 0 })
+  @Column({ default: 0 })
+  koWins: number;
+
+  @Field({ defaultValue: 0 })
+  @Column({ default: 0 })
+  submissionWins: number;
+}

--- a/src/fighters/fighters.module.ts
+++ b/src/fighters/fighters.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Fighter } from './domain/fighter.entity';
+import { FightersService } from './application/fighters.service';
+import { FightersResolver } from './presentation/fighters.resolver';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Fighter])],
+  providers: [FightersService, FightersResolver],
+  exports: [FightersService],
+})
+export class FightersModule {}

--- a/src/fighters/presentation/dto/create-fighter.input.ts
+++ b/src/fighters/presentation/dto/create-fighter.input.ts
@@ -1,0 +1,16 @@
+import { Field, InputType } from '@nestjs/graphql';
+import { IsNotEmpty } from 'class-validator';
+
+@InputType()
+export class CreateFighterInput {
+  @Field()
+  @IsNotEmpty()
+  name: string;
+
+  @Field()
+  @IsNotEmpty()
+  weightClass: string;
+
+  @Field({ nullable: true })
+  dob?: string;
+}

--- a/src/fighters/presentation/fighters.resolver.ts
+++ b/src/fighters/presentation/fighters.resolver.ts
@@ -1,0 +1,24 @@
+import { Args, Int, Mutation, Query, Resolver } from '@nestjs/graphql';
+import { FightersService } from '../application/fighters.service';
+import { Fighter } from '../domain/fighter.entity';
+import { CreateFighterInput } from './dto/create-fighter.input';
+
+@Resolver(() => Fighter)
+export class FightersResolver {
+  constructor(private service: FightersService) {}
+
+  @Query(() => [Fighter])
+  fighters() {
+    return this.service.findAll();
+  }
+
+  @Query(() => Fighter, { nullable: true })
+  fighter(@Args('id', { type: () => Int }) id: number) {
+    return this.service.findOne(id);
+  }
+
+  @Mutation(() => Fighter)
+  createFighter(@Args('input') input: CreateFighterInput) {
+    return this.service.create(input);
+  }
+}

--- a/src/fights/application/fights.service.ts
+++ b/src/fights/application/fights.service.ts
@@ -1,0 +1,60 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Fight } from '../domain/fight.entity';
+import { ScheduleFightInput } from '../presentation/dto/schedule-fight.input';
+import { EventsService } from '../../events/application/events.service';
+import { FightersService } from '../../fighters/application/fighters.service';
+import { RankingService } from '../../rankings/application/ranking.service';
+
+@Injectable()
+export class FightsService {
+  constructor(
+    @InjectRepository(Fight)
+    private fights: Repository<Fight>,
+    private eventsService: EventsService,
+    private fightersService: FightersService,
+    private rankingService: RankingService,
+  ) {}
+
+  async scheduleFight(input: ScheduleFightInput) {
+    const event = await this.eventsService.findOne(input.eventId);
+    const fighterA = await this.fightersService.findOne(input.fighterAId);
+    const fighterB = await this.fightersService.findOne(input.fighterBId);
+    const fight = this.fights.create({
+      event,
+      fighterA,
+      fighterB,
+      method: input.method,
+    });
+    return this.fights.save(fight);
+  }
+
+  async submitResult(
+    fightId: number,
+    result: { winnerId?: number; method: string; round?: number; time?: string }
+  ) {
+    const fight = await this.fights.findOne({ where: { id: fightId }, relations: ['fighterA', 'fighterB', 'event'] });
+    if (!fight) return null;
+    fight.method = result.method;
+    fight.outcomeRound = result.round;
+    fight.outcomeTime = result.time;
+    const draw = !result.winnerId;
+    if (result.winnerId) {
+      const winner = await this.fightersService.findOne(result.winnerId);
+      fight.winner = winner;
+    }
+    await this.fights.save(fight);
+
+    const weightClass = fight.fighterA.weightClass;
+    const loserId = fight.winner?.id === fight.fighterA.id ? fight.fighterB.id : fight.fighterA.id;
+    await this.rankingService.updateRankingsForFight({
+      weightClass,
+      winnerId: fight.winner?.id,
+      loserId,
+      method: result.method,
+      draw,
+    });
+    return fight;
+  }
+}

--- a/src/fights/domain/fight.entity.ts
+++ b/src/fights/domain/fight.entity.ts
@@ -1,0 +1,36 @@
+import { Field, ObjectType } from '@nestjs/graphql';
+import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { Fighter } from '../../fighters/domain/fighter.entity';
+import { Event } from '../../events/domain/event.entity';
+
+@ObjectType()
+@Entity('fights')
+export class Fight {
+  @Field()
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(() => Event, event => event.fights)
+  event: Event;
+
+  @ManyToOne(() => Fighter)
+  fighterA: Fighter;
+
+  @ManyToOne(() => Fighter)
+  fighterB: Fighter;
+
+  @ManyToOne(() => Fighter, { nullable: true })
+  winner?: Fighter;
+
+  @Field()
+  @Column()
+  method: string;
+
+  @Field({ nullable: true })
+  @Column({ nullable: true })
+  outcomeRound?: number;
+
+  @Field({ nullable: true })
+  @Column({ nullable: true })
+  outcomeTime?: string;
+}

--- a/src/fights/fights.module.ts
+++ b/src/fights/fights.module.ts
@@ -1,0 +1,20 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Fight } from './domain/fight.entity';
+import { FightsService } from './application/fights.service';
+import { FightsResolver } from './presentation/fights.resolver';
+import { EventsModule } from '../events/events.module';
+import { FightersModule } from '../fighters/fighters.module';
+import { RankingsModule } from '../rankings/rankings.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Fight]),
+    EventsModule,
+    FightersModule,
+    RankingsModule,
+  ],
+  providers: [FightsService, FightsResolver],
+  exports: [FightsService],
+})
+export class FightsModule {}

--- a/src/fights/presentation/dto/schedule-fight.input.ts
+++ b/src/fights/presentation/dto/schedule-fight.input.ts
@@ -1,0 +1,20 @@
+import { Field, InputType, Int } from '@nestjs/graphql';
+import { IsInt } from 'class-validator';
+
+@InputType()
+export class ScheduleFightInput {
+  @Field(type => Int)
+  @IsInt()
+  eventId: number;
+
+  @Field(type => Int)
+  @IsInt()
+  fighterAId: number;
+
+  @Field(type => Int)
+  @IsInt()
+  fighterBId: number;
+
+  @Field()
+  method: string;
+}

--- a/src/fights/presentation/fights.resolver.ts
+++ b/src/fights/presentation/fights.resolver.ts
@@ -1,0 +1,25 @@
+import { Args, Int, Mutation, Query, Resolver } from '@nestjs/graphql';
+import { FightsService } from '../application/fights.service';
+import { Fight } from '../domain/fight.entity';
+import { ScheduleFightInput } from './dto/schedule-fight.input';
+
+@Resolver(() => Fight)
+export class FightsResolver {
+  constructor(private service: FightsService) {}
+
+  @Mutation(() => Fight)
+  scheduleFight(@Args('input') input: ScheduleFightInput) {
+    return this.service.scheduleFight(input);
+  }
+
+  @Mutation(() => Fight, { nullable: true })
+  submitFightResult(
+    @Args('fightId', { type: () => Int }) fightId: number,
+    @Args('winnerId', { type: () => Int, nullable: true }) winnerId: number,
+    @Args('method') method: string,
+    @Args('round', { type: () => Int, nullable: true }) round?: number,
+    @Args('time', { nullable: true }) time?: string,
+  ) {
+    return this.service.submitResult(fightId, { winnerId, method, round, time });
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,8 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(3000);
+}
+bootstrap();

--- a/src/rankings/application/ranking.service.ts
+++ b/src/rankings/application/ranking.service.ts
@@ -1,0 +1,56 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Ranking } from '../domain/ranking.entity';
+import { Fighter } from '../../fighters/domain/fighter.entity';
+
+@Injectable()
+export class RankingService {
+  constructor(
+    @InjectRepository(Ranking)
+    private rankings: Repository<Ranking>,
+    @InjectRepository(Fighter)
+    private fighters: Repository<Fighter>,
+  ) {}
+
+  getRankings(weightClass: string) {
+    return this.rankings.find({ where: { weightClass }, relations: ["fighter"], order: { rank: "ASC" } });
+  }
+
+  async updateRankingsForFight(fight: {
+    weightClass: string;
+    winnerId?: number;
+    loserId?: number;
+    method: string;
+    draw: boolean;
+  }) {
+    const { weightClass, winnerId, loserId, method, draw } = fight;
+    if (draw) {
+      await this.addPoints(weightClass, winnerId!, 1);
+      await this.addPoints(weightClass, loserId!, 1);
+    } else if (winnerId) {
+      const points = method === 'Decision' ? 3 : 4;
+      await this.addPoints(weightClass, winnerId, points);
+    }
+    await this.recalculateRanks(weightClass);
+  }
+
+  private async addPoints(weightClass: string, fighterId: number, points: number) {
+    let ranking = await this.rankings.findOne({ where: { fighter: { id: fighterId }, weightClass }, relations: ['fighter'] });
+    if (!ranking) {
+      const fighter = await this.fighters.findOne({ where: { id: fighterId } });
+      if (!fighter) return;
+      ranking = this.rankings.create({ fighter, weightClass, points: 0, rank: 0 });
+    }
+    ranking.points += points;
+    await this.rankings.save(ranking);
+  }
+
+  private async recalculateRanks(weightClass: string) {
+    const entries = await this.rankings.find({ where: { weightClass }, order: { points: 'DESC' }, relations: ['fighter'] });
+    for (let i = 0; i < entries.length; i++) {
+      entries[i].rank = i + 1;
+      await this.rankings.save(entries[i]);
+    }
+  }
+}

--- a/src/rankings/domain/ranking.entity.ts
+++ b/src/rankings/domain/ranking.entity.ts
@@ -1,0 +1,26 @@
+import { Field, ObjectType } from '@nestjs/graphql';
+import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { Fighter } from '../../fighters/domain/fighter.entity';
+
+@ObjectType()
+@Entity('rankings')
+export class Ranking {
+  @Field()
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Field()
+  @Column()
+  weightClass: string;
+
+  @ManyToOne(() => Fighter)
+  fighter: Fighter;
+
+  @Field()
+  @Column({ default: 0 })
+  points: number;
+
+  @Field()
+  @Column()
+  rank: number;
+}

--- a/src/rankings/presentation/rankings.resolver.ts
+++ b/src/rankings/presentation/rankings.resolver.ts
@@ -1,0 +1,13 @@
+import { Args, Query, Resolver } from '@nestjs/graphql';
+import { RankingService } from '../application/ranking.service';
+import { Ranking } from '../domain/ranking.entity';
+
+@Resolver(() => Ranking)
+export class RankingsResolver {
+  constructor(private service: RankingService) {}
+
+  @Query(() => [Ranking])
+  rankings(@Args('weightClass') weightClass: string) {
+    return this.service.getRankings(weightClass);
+  }
+}

--- a/src/rankings/rankings.module.ts
+++ b/src/rankings/rankings.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Ranking } from './domain/ranking.entity';
+import { RankingService } from './application/ranking.service';
+import { Fighter } from '../fighters/domain/fighter.entity';
+import { RankingsResolver } from './presentation/rankings.resolver';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Ranking, Fighter])],
+  providers: [RankingService, RankingsResolver],
+  exports: [RankingService],
+})
+export class RankingsModule {}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2017",
+    "lib": ["es2021"],
+    "declaration": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- set up NestJS project skeleton with TypeORM and GraphQL
- add domain entities for fighters, events, fights and rankings
- implement services and resolvers for basic CRUD
- provide ranking service with simple points algorithm
- document ranking algorithm and development steps in README

## Testing
- `git status --short`
